### PR TITLE
Add description arg to static_routes.py

### DIFF
--- a/plugins/module_utils/network/om/argspec/static_routes/static_routes.py
+++ b/plugins/module_utils/network/om/argspec/static_routes/static_routes.py
@@ -43,6 +43,7 @@ class StaticRoutesArgs(object):  # pylint: disable=R0903
                                             'destination_netmask': {'type': 'int'},
                                             'gateway_address': {'type': 'str'},
                                             'id': {'type': 'str'},
+                                            'description': {'type': 'str'},
                                             'interface': {'type': 'str'},
                                             'metric': {'type': 'int'}},
                                 'type': 'list'},


### PR DESCRIPTION
Allow description to be set when configuring static routes